### PR TITLE
BUILD-5100 Setup gh-action_jira-create

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>SonarSource/renovate-config:re-team"
+  ]
+}

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -1,0 +1,268 @@
+name: IT Tests
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  id-token: write
+
+jobs:
+
+  it-tests-use-only-required-input-values:
+    name: "IT Test - given only required inputs values should create a new issue successfully"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Jira sandbox secrets
+        id: vault-jira-sandbox-secrets
+        uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
+        with:
+          secrets: |
+            operations/team/re/kv/data/jira-sandbox url | jira_url;
+            operations/team/re/kv/data/jira-sandbox user | jira_user;
+            operations/team/re/kv/data/jira-sandbox password | jira_password;
+      - name: Setup jira cli
+        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
+        with:
+          version: 1.0.27
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Given the gh-action is used with only required inputs
+        id: test-data
+        uses: ./
+        with:
+          project: "BUILD"
+          issuetype: "Task"
+          summary: "[gh-action_jira-create] IT Test only required input fields - ${{github.run_id}}"
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then outputs.issue value must be present and start with BUILD
+        with:
+          expected: BUILD-
+          actual: ${{ steps.test-data.outputs.issue }}
+          comparison: startsWith
+
+  it-tests-check-all-inputs:
+    name: "IT Test - given all inputs values are provided, they should be inserted correctly within the issue"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Jira sandbox secrets
+        id: vault-jira-sandbox-secrets
+        uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
+        with:
+          secrets: |
+            operations/team/re/kv/data/jira-sandbox url | jira_url;
+            operations/team/re/kv/data/jira-sandbox user | jira_user;
+            operations/team/re/kv/data/jira-sandbox password | jira_password;
+      - name: Setup jira cli
+        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
+        with:
+          version: 1.0.27
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Given the gh-action is used correctly with all available inputs
+        id: test-data
+        uses: ./
+        with:
+          project: "BUILD"
+          issuetype: "Task"
+          summary: "[gh-action_jira-create] IT Test all input fields correctly filled - ${{github.run_id}}"
+          description: "This is a generated Jira issue used by gh-action_jira-create integrations test. Please ignore it."
+          fields: |
+            {
+              "priority": {"name": "Normal"}
+            }
+
+      - name: Retrieve created Jira issue metadata
+        id: jira-content
+        run: |
+          set +e
+          OUTPUT=$(jira view ${{ steps.test-data.outputs.issue }} -t debug)
+          STATUS=$?
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> dump-jira-exec.log
+          {
+            echo 'json_payload<<EOF'
+            cat dump-jira-exec.log
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+
+      - name: "Dump Jira issue payload"
+        run: cat dump-jira-exec.log
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the Jira command to extract ticket details should have run smoothly
+        with:
+          expected: 0
+          actual: ${{ steps.jira-content.outputs.status }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue description should match what is given as input
+        with:
+          expected: "This is a generated Jira issue used by gh-action_jira-create integrations test. Please ignore it."
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.description }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue summary should match what is given as input
+        with:
+          expected: "[gh-action_jira-create] IT Test all input fields correctly filled - "
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.summary }}
+          comparison: startsWith
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue status should be Open
+        with:
+          expected: "Open"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.status.name }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue priority should match what is given as input
+        with:
+          expected: "Normal"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.priority.name }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue type should match what is given as input
+        with:
+          expected: "Task"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.issuetype.name }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue project should match what is given as input
+        with:
+          expected: "BUILD"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.project.key }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue reporter should match tech user
+        with:
+          expected: "JIRA Tech User Release Engineers"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.reporter.displayName }}
+          comparison: exact
+
+      - name: Mark test ticket as resolved
+        run: jira resolve ${{ steps.test-data.outputs.issue }}
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+
+      - name: Mark test ticket as closed
+        run: jira close ${{ steps.test-data.outputs.issue }}
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+
+  it-tests-description-markdown-to-jira-markup-conversion:
+    name: "IT Test - given description contains markdown, it should be converted correctly to Jira Markup"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve Jira sandbox secrets
+        id: vault-jira-sandbox-secrets
+        uses: SonarSource/vault-action-wrapper@d0877ce7085bc313bd7a7b99c4e4489d42fb40e1 # tag=3.0.0
+        with:
+          secrets: |
+            operations/team/re/kv/data/jira-sandbox url | jira_url;
+            operations/team/re/kv/data/jira-sandbox user | jira_user;
+            operations/team/re/kv/data/jira-sandbox password | jira_password;
+      - name: Setup jira cli
+        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
+        with:
+          version: 1.0.27
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Given the gh-action is used correctly with a Markdown description
+        id: test-data
+        uses: ./
+        with:
+          project: "BUILD"
+          issuetype: "Task"
+          summary: "[gh-action_jira-create] IT Test Markdown description - ${{github.run_id}}"
+          description: "**bold** *italic*"
+
+      - name: Retrieve created Jira issue metadata
+        id: jira-content
+        run: |
+          set +e
+          OUTPUT=$(jira view ${{ steps.test-data.outputs.issue }} -t debug)
+          STATUS=$?
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> dump-jira-exec.log
+          {
+            echo 'json_payload<<EOF'
+            cat dump-jira-exec.log
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+      - name: "Dump Jira issue payload"
+        run: cat dump-jira-exec.log
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the Jira command to extract ticket details should have run smoothly
+        with:
+          expected: 0
+          actual: ${{ steps.jira-content.outputs.status }}
+          comparison: exact
+
+      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+        name: Then the issue description should be converted to Jira markdown
+        with:
+          expected: "*bold* _italic_"
+          actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.description }}
+          comparison: exact
+
+      - name: Mark test ticket as resolved
+        run: jira resolve ${{ steps.test-data.outputs.issue }}
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+
+      - name: Mark test ticket as closed
+        run: jira close ${{ steps.test-data.outputs.issue }}
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+
+  it-tests:
+    name: "All IT Tests have to pass"
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      # Add your tests here so that they prevent the merge of broken changes
+      - it-tests-use-only-required-input-values
+      - it-tests-check-all-inputs
+      - it-tests-description-markdown-to-jira-markup-conversion
+    steps:
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Pre-commit checks
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@2f1b605a435e0896282366dce6ca4ce9b98705b5 # 0.0.6
+        with:
+          extra-args: >
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  line_length: 120
+  tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 32ee411cf36142e6082f10870ae62172ce9af133 # frozen: 35.32.0
+    hooks:
+      - id: renovate-config-validator
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 20447075e31543a8b125f2df18d75f3b5e7d4d2e # frozen: 0.22.0
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    hooks:
+      - id: markdownlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
     hooks:

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,31 @@
+# Developer notes
+
+> You want to contribute to this project ? Please read the following
+
+## IT Tests
+
+This project define integrations tests in `.github/workflows/it-test.yml`.
+
+Test assertions are done using [nick-fields/assert-action](https://github.com/nick-fields/assert-action).
+
+Resources used for tests are placed within `.github/tests/resources/` directory
+
+### Side note
+
+At the moment, GitHub branch protection do not allow to define checks based
+on a REGEX as we can find in other CI tools such as Jenkins.
+
+In order to work around this limitation this project make
+use of [re-actors/alls-green](https://github.com/re-actors/alls-green).
+
+All tests have to be declared in `.github/workflows/it-test.yml`
+the job called `it-tests` declares a list of needs:
+
+```yaml
+    ...
+    needs:
+       ...
+      - it-tests-output-logs-failure
+      - it-tests-output-logs-success
+      - < your new test > <-------------- Add your tests here
+```

--- a/DEV.md
+++ b/DEV.md
@@ -4,7 +4,7 @@
 
 ## IT Tests
 
-This project define integrations tests in `.github/workflows/it-test.yml`.
+This project defines integration tests in `.github/workflows/it-test.yml`.
 
 Test assertions are done using [nick-fields/assert-action](https://github.com/nick-fields/assert-action).
 
@@ -12,14 +12,14 @@ Resources used for tests are placed within `.github/tests/resources/` directory
 
 ### Side note
 
-At the moment, GitHub branch protection do not allow to define checks based
+At the moment, GitHub branch protection does not allow to define checks based
 on a REGEX as we can find in other CI tools such as Jenkins.
 
-In order to work around this limitation this project make
+In order to work around this limitation, this project make
 use of [re-actors/alls-green](https://github.com/re-actors/alls-green).
 
-All tests have to be declared in `.github/workflows/it-test.yml`
-the job called `it-tests` declares a list of needs:
+All tests have to be declared in `.github/workflows/it-test.yml`.
+The job called `it-tests` declares a list of needs:
 
 ```yaml
     ...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # gh-action_jira-create
-Wrapper for github action atlassian/gajira-create
+
+![GitHub Release](https://img.shields.io/github/v/release/SonarSource/gh-action_jira-create)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_jira-create&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_jira-create)
+[![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_jira-create/actions/workflows/it-test.yml/badge.svg)](https://github.com/SonarSource/gh-action_jira-create/actions/workflows/it-test.yml)
+
+Create jira ticket
+
+> Note
+> This is a wrapper for GitHub action [atlassian/gajira-create](https://github.com/atlassian/gajira-create?tab=readme-ov-file)
+> with some extra features such as Markdown support for issue description.
+
+## Usage
+
+### Create a simple Jira issue using Markdown
+
+```yaml
+steps:
+  - uses: SonarSource/gh-action_jira-create@0.0.1 <--- replace with the last tag
+    with:
+      project: <Jira project key>
+      issuetype: <Task, ...>
+      summary: "Summary"
+      description: "**some** description"
+```
+
+### Create a Jira issue with extra fields
+
+```yaml
+steps:
+  - uses: SonarSource/gh-action_jira-create@0.0.1 <--- replace with the last tag
+    with:
+      project: <Jira project key>
+      issuetype: <Task, ...>
+      summary: "Summary"
+      description: "**some** description"
+      fields: |
+        {
+          "priority": {"name": "Normal"}
+        }
+```
+
+## Inputs
+
+| Input name    | Description                                           | Required |
+|---------------|-------------------------------------------------------|----------|
+| `project`     | Specify Jira project key                              | yes      |
+| `issuetype`   | Jira issue type (i.e: Task)                           | yes      |
+| `summary`     | Summary (= title) of the Jira issue                   | yes      |
+| `description` | Description of the Jira issue (Markdown is supported) | no       |
+| `fields`      | Allow to define some extra fields such as `priority`  | no       |
+
+## Outputs
+
+| Input name    | Description                                           |
+|---------------|-------------------------------------------------------|
+| `issue`       | Issue identifier (i.e: `JIRA-42`)                     |
+
+## Versioning
+
+This project is using [Semantic Versioning](https://semver.org/).
+
+The `master` branch shall not be referenced by end-users,
+please use tags instead and [Renovate](https://docs.renovatebot.com/) or
+[Dependabot](https://docs.github.com/en/code-security/dependabot) to stay up to date.
+
+## Contribute
+
+Contributions are welcome, please have a look at [DEV.md](./DEV.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_gh-action_jira-create&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_gh-action_jira-create)
 [![.github/workflows/it-test.yml](https://github.com/SonarSource/gh-action_jira-create/actions/workflows/it-test.yml/badge.svg)](https://github.com/SonarSource/gh-action_jira-create/actions/workflows/it-test.yml)
 
-Create jira ticket
+Create Jira ticket
 
 > Note
 > This is a wrapper for GitHub action [atlassian/gajira-create](https://github.com/atlassian/gajira-create?tab=readme-ov-file)
@@ -60,8 +60,8 @@ steps:
 
 This project is using [Semantic Versioning](https://semver.org/).
 
-The `master` branch shall not be referenced by end-users,
-please use tags instead and [Renovate](https://docs.renovatebot.com/) or
+The `master` branch shall not be referenced by end-users.
+Please use tags instead and [Renovate](https://docs.renovatebot.com/) or
 [Dependabot](https://docs.github.com/en/code-security/dependabot) to stay up to date.
 
 ## Contribute

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,40 @@
+name: gh-action_jira-create
+description: Create a new Jira issue
+inputs:
+  project:
+    description: Key of the project
+    required: true
+  issuetype:
+    description: "Type of the issue to be created. Example: 'Task'"
+    required: true
+  summary:
+    description: Issue summary
+    required: true
+  description:
+    description: Issue description
+    required: false
+  fields:
+    description: Additional fields in JSON format
+    required: false
+outputs:
+  issue:
+    description: Key of the newly created issue
+    value: ${{ steps.create.outputs.issue }}
+
+runs:
+  using: composite
+  steps:
+    - uses: peter-evans/jira2md@05e674767734625c20b91e7a17fd986152a7bb99 # v1.1.0
+      id: md2jira
+      with:
+        input-text: ${{ inputs.description }}
+        mode: md2jira
+    - name: Create Jira issue
+      id: create
+      uses: atlassian/gajira-create@1ff0b6bd115a780592b47bfbb63fc4629132e6ec # v3
+      with:
+        project: ${{ inputs.project }}
+        issuetype: ${{ inputs.issuetype }}
+        summary: ${{ inputs.summary }}
+        description: ${{ steps.md2jira.outputs.output-text }}
+        fields: ${{ inputs.fields }}


### PR DESCRIPTION
# BUILD-5100 gh-action_jira-create

**TLDR;** This action acts as a wrapper around no longer supported [atlassian/gajira-create](https://github.com/atlassian/gajira-create). 

Bonus: It also enriches it by natively supporting Markdown syntax in the issue description :rocket: 

## Changes

- [x] Document the project in order to help contributors and end users in `README.md` and `DEV.md`
- [x] Setup some integrations tests to avoid regressions in `.github/workflows/it-test.yml`
- [x] Setup Renovate - That way the project tech debt stays under control
- [x] Setup pre-commit - That way the codebase gets some enforced rules to stay intentional

## How was it tested?

- [x] IT tests https://github.com/SonarSource/gh-action_jira-create/actions/runs/9264781665
- [x] Pre-commit https://github.com/SonarSource/gh-action_jira-create/actions/runs/9264701033/job/25485269497

## Depends on
* https://github.com/SonarSource/gh-action_jira-create/pull/2