### PR TITLE
BUILD-8293: fix integration test

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -126,9 +126,9 @@ jobs:
           comparison: startsWith
 
       - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
-        name: Then the issue status should be To Do
+        name: Then the issue status should be Open
         with:
-          expected: "To Do"
+          expected: "Open"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.status.name }}
           comparison: exact
 


### PR DESCRIPTION
Fixing the `Then the issue status should be To do ` integration test. I think that we forgot to update this one because when we create a Jira ticket, it's in Open state first:
![image](https://github.com/user-attachments/assets/ef28a9ef-9692-4c12-900f-eb8f0d00889c)
