### PR TITLE
BUILD-8875: Migrate to standardized GitHub runner names

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -11,7 +11,7 @@ jobs:
 
   it-tests-use-only-required-input-values:
     name: "IT Test - given only required inputs values should create a new issue successfully"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -48,7 +48,7 @@ jobs:
 
   it-tests-check-all-inputs:
     name: "IT Test - given all inputs values are provided, they should be inserted correctly within the issue"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -176,7 +176,7 @@ jobs:
 
   it-tests-description-markdown-to-jira-markup-conversion:
     name: "IT Test - given description contains markdown, it should be converted correctly to Jira Markup"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -257,7 +257,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     steps:
       - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7
         with:


### PR DESCRIPTION
## GitHub Actions Runner Migration

This PR updates GitHub Actions workflows to use our new standardized runner naming convention.

### Changes
- Updates runner names in workflow files to new standardized format
- No functional changes to your CI/CD pipelines
- All existing functionality remains identical

### Runner Mappings
| Old Runner | New Runner |
|------------|------------|
| sonar-runner-large | github-ubuntu-latest-s |
| ubuntu-latest-large | github-ubuntu-latest-s |
| windows-latest-large | github-windows-latest-s |
| ubuntu-24.04-large | github-ubuntu-latest-s |
| sonar-runner-large-arm | github-ubuntu-24.04-arm-s |
| ubuntu-24.04-arm-large | github-ubuntu-24.04-arm-s |

### What You Need to Do
1. Review the changes in this PR
2. Merge when ready - no additional action required
3. Old runners will remain available during transition

### Additional Information
For more details about GitHub Actions runners and their specifications, see our [GitHub Actions Runner Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub).

This is an automated migration. Questions? Contact the **Engineering Experience squad**.
