### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -11,7 +11,7 @@ jobs:
 
   it-tests-use-only-required-input-values:
     name: "IT Test - given only required inputs values should create a new issue successfully"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -48,7 +48,7 @@ jobs:
 
   it-tests-check-all-inputs:
     name: "IT Test - given all inputs values are provided, they should be inserted correctly within the issue"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -176,7 +176,7 @@ jobs:
 
   it-tests-description-markdown-to-jira-markup-conversion:
     name: "IT Test - given description contains markdown, it should be converted correctly to Jira Markup"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
@@ -257,7 +257,7 @@ jobs:
 
   it-tests:
     name: "All IT Tests have to pass"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     if: always()
     needs:
       # Add your tests here so that they prevent the merge of broken changes

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7
         with:


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/it-test.yml`
- `.github/workflows/pre-commit.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.