### PR TITLE
BUILD-10781 Bump peter-evans/jira2md to v3 (Node 24)

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
-        uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             operations/team/re/kv/data/jira-sandbox url | jira_url;
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
-        uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             operations/team/re/kv/data/jira-sandbox url | jira_url;
@@ -180,7 +180,7 @@ jobs:
     steps:
       - name: Retrieve Jira sandbox secrets
         id: vault-jira-sandbox-secrets
-        uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             operations/team/re/kv/data/jira-sandbox url | jira_url;

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -31,7 +31,7 @@ jobs:
           JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
           JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
           JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used with only required inputs
         id: test-data
         uses: ./
@@ -39,7 +39,7 @@ jobs:
           project: "BUILD"
           issuetype: "Feature"
           summary: "[gh-action_jira-create] IT Test only required input fields - ${{github.run_id}}"
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then outputs.issue value must be present and start with BUILD
         with:
           expected: BUILD-
@@ -68,7 +68,7 @@ jobs:
           JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
           JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
           JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used correctly with all available inputs
         id: test-data
         uses: ./
@@ -104,56 +104,56 @@ jobs:
       - name: "Dump Jira issue payload"
         run: cat dump-jira-exec.log
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the Jira command to extract ticket details should have run smoothly
         with:
           expected: 0
           actual: ${{ steps.jira-content.outputs.status }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue description should match what is given as input
         with:
           expected: "This is a generated Jira issue used by gh-action_jira-create integrations test. Please ignore it."
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.description }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue summary should match what is given as input
         with:
           expected: "[gh-action_jira-create] IT Test all input fields correctly filled - "
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.summary }}
           comparison: startsWith
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue status should be Open
         with:
           expected: "Open"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.status.name }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue priority should match what is given as input
         with:
           expected: "Normal"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.priority.name }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue type should match what is given as input
         with:
           expected: "Feature"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.issuetype.name }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue project should match what is given as input
         with:
           expected: "BUILD"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.project.key }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue reporter should match tech user
         with:
           expected: "JIRA Tech User Release Engineers"
@@ -196,7 +196,7 @@ jobs:
           JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
           JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
           JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used correctly with a Markdown description
         id: test-data
         uses: ./
@@ -227,14 +227,14 @@ jobs:
       - name: "Dump Jira issue payload"
         run: cat dump-jira-exec.log
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the Jira command to extract ticket details should have run smoothly
         with:
           expected: 0
           actual: ${{ steps.jira-content.outputs.status }}
           comparison: exact
 
-      - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
+      - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
         name: Then the issue description should be converted to Jira markdown
         with:
           expected: "*bold* _italic_"

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./
         with:
           project: "BUILD"
-          issuetype: "Task"
+          issuetype: "Feature"
           summary: "[gh-action_jira-create] IT Test only required input fields - ${{github.run_id}}"
       - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
         name: Then outputs.issue value must be present and start with BUILD
@@ -74,7 +74,7 @@ jobs:
         uses: ./
         with:
           project: "BUILD"
-          issuetype: "Task"
+          issuetype: "Feature"
           summary: "[gh-action_jira-create] IT Test all input fields correctly filled - ${{github.run_id}}"
           description: "This is a generated Jira issue used by gh-action_jira-create integrations test. Please ignore it."
           fields: |
@@ -142,7 +142,7 @@ jobs:
       - uses: nick-fields/assert-action@aa0067e01f0f6545c31755d6ca128c5a3a14f6bf # v2
         name: Then the issue type should match what is given as input
         with:
-          expected: "Task"
+          expected: "Feature"
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.issuetype.name }}
           comparison: exact
 
@@ -202,7 +202,7 @@ jobs:
         uses: ./
         with:
           project: "BUILD"
-          issuetype: "Task"
+          issuetype: "Feature"
           summary: "[gh-action_jira-create] IT Test Markdown description - ${{github.run_id}}"
           description: "**bold** *italic*"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
-      - uses: SonarSource/gh-action_pre-commit@3d5b503c1ce51d0f92665875b9bea716eff1e70f # 1.0.7
+      - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: peter-evans/jira2md@71f20480efa44538956efcce4f764e7e8f959781 # v2.0.0
+    - uses: peter-evans/jira2md@c723431952015df5d3cdc8e17b82cb66df5415db # v3.0.0
       id: md2jira
       with:
         input-text: ${{ inputs.description }}


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02**.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- `peter-evans/jira2md` v2.0.0 → **v3.0.0** (Node 24).

## What did NOT change (blocker)

- `atlassian/gajira-create@v3` — Atlassian hasn't published a Node 24 major. The action's latest release on GitHub is `v3` (from 2022). Once GitHub starts enforcing the Node 20 deprecation, this action will emit warnings and eventually break. Options to track:
  1. Wait for Atlassian to ship a Node 24 release.
  2. Replace `gajira-create` with an alternative (custom REST call, community fork, or the Atlassian MCP).


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `vault-action-wrapper` to `3.5.0` in `.github/workflows/it-test.yml`.
  - Upgraded `actions/checkout` to `v6.0.2` and `nick-fields/assert-action` to `v3.0.0` in IT workflows.
  - Bumped `SonarSource/gh-action_pre-commit` to `1.2.0` in `.github/workflows/pre-commit.yml`.
- **Test updates:**
  - Updated integration tests in `.github/workflows/it-test.yml` to use `Feature` instead of `Task` as the issue type.

<sub>This will update automatically on new commits.</sub>