### PR TITLE
BUILD-11506 Replace atlassian/gajira-* with direct Jira REST calls

### DIFF
--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -21,20 +21,14 @@ jobs:
             operations/team/re/kv/data/jira-sandbox url | jira_url;
             operations/team/re/kv/data/jira-sandbox user | jira_user;
             operations/team/re/kv/data/jira-sandbox password | jira_password;
-      - name: Setup jira cli
-        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
-        with:
-          version: 1.0.27
-      - name: Login
-        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used with only required inputs
         id: test-data
         uses: ./
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
         with:
           project: "BUILD"
           issuetype: "Feature"
@@ -58,20 +52,14 @@ jobs:
             operations/team/re/kv/data/jira-sandbox url | jira_url;
             operations/team/re/kv/data/jira-sandbox user | jira_user;
             operations/team/re/kv/data/jira-sandbox password | jira_password;
-      - name: Setup jira cli
-        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
-        with:
-          version: 1.0.27
-      - name: Login
-        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used correctly with all available inputs
         id: test-data
         uses: ./
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
         with:
           project: "BUILD"
           issuetype: "Feature"
@@ -84,28 +72,34 @@ jobs:
 
       - name: Retrieve created Jira issue metadata
         id: jira-content
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+          ISSUE_KEY: ${{ steps.test-data.outputs.issue }}
         run: |
           set +e
           sleep 5 # Give some time to the Jira automation to transit issue Open -> Todo
-          OUTPUT=$(jira view ${{ steps.test-data.outputs.issue }} -t debug)
-          STATUS=$?
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "$OUTPUT" >> dump-jira-exec.log
+          body="$(mktemp)"
+          code="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
+            --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            --header 'Accept: application/json' \
+            "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}")"
+          status=0
+          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          cp "$body" dump-jira-exec.log
           {
             echo 'json_payload<<EOF'
             cat dump-jira-exec.log
             echo EOF
           } >> "$GITHUB_OUTPUT"
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
 
       - name: "Dump Jira issue payload"
         run: cat dump-jira-exec.log
 
       - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
-        name: Then the Jira command to extract ticket details should have run smoothly
+        name: Then the Jira request to extract ticket details should have run smoothly
         with:
           expected: 0
           actual: ${{ steps.jira-content.outputs.status }}
@@ -160,19 +154,32 @@ jobs:
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.reporter.displayName }}
           comparison: exact
 
-      - name: Mark test ticket as resolved
-        run: jira resolve ${{ steps.test-data.outputs.issue }}
+      - name: Resolve and close the test ticket
+        if: always() && steps.test-data.outputs.issue != ''
         env:
           JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
           JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
           JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
-
-      - name: Mark test ticket as closed
-        run: jira close ${{ steps.test-data.outputs.issue }}
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+          ISSUE_KEY: ${{ steps.test-data.outputs.issue }}
+        run: |
+          set +e
+          # Best-effort cleanup of the sandbox ticket (non-fatal): drive it to a terminal state
+          # by name, regardless of the exact workflow transition ids.
+          transition() {
+            tid="$(curl --silent --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+              --header 'Accept: application/json' \
+              "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions" \
+              | jq -r --arg n "$1" '.transitions[] | select(.name | ascii_downcase == ($n | ascii_downcase)) | .id' | head -n1)"
+            if [ -n "${tid}" ] && [ "${tid}" != "null" ]; then
+              curl --silent --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+                --header 'Content-Type: application/json' --request POST \
+                --data "{\"transition\":{\"id\":\"${tid}\"}}" \
+                "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions"
+            fi
+          }
+          for name in "Resolve Issue" "Resolve" "Done" "Close Issue" "Close"; do
+            transition "${name}"
+          done
 
   it-tests-description-markdown-to-jira-markup-conversion:
     name: "IT Test - given description contains markdown, it should be converted correctly to Jira Markup"
@@ -186,20 +193,14 @@ jobs:
             operations/team/re/kv/data/jira-sandbox url | jira_url;
             operations/team/re/kv/data/jira-sandbox user | jira_user;
             operations/team/re/kv/data/jira-sandbox password | jira_password;
-      - name: Setup jira cli
-        uses: atlassian/gajira-cli@7b8487d76cd88bf5d50ba00c6cca6edff1ddd507 # v3
-        with:
-          version: 1.0.27
-      - name: Login
-        uses: atlassian/gajira-login@ca13f8850ea309cf44a6e4e0c49d9aa48ac3ca4c # v3
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Given the gh-action is used correctly with a Markdown description
         id: test-data
         uses: ./
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
         with:
           project: "BUILD"
           issuetype: "Feature"
@@ -208,27 +209,33 @@ jobs:
 
       - name: Retrieve created Jira issue metadata
         id: jira-content
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+          ISSUE_KEY: ${{ steps.test-data.outputs.issue }}
         run: |
           set +e
           sleep 5 # Give some time to the Jira automation to transit issue Open -> Todo
-          OUTPUT=$(jira view ${{ steps.test-data.outputs.issue }} -t debug)
-          STATUS=$?
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "$OUTPUT" >> dump-jira-exec.log
+          body="$(mktemp)"
+          code="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
+            --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            --header 'Accept: application/json' \
+            "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}")"
+          status=0
+          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          cp "$body" dump-jira-exec.log
           {
             echo 'json_payload<<EOF'
             cat dump-jira-exec.log
             echo EOF
           } >> "$GITHUB_OUTPUT"
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
       - name: "Dump Jira issue payload"
         run: cat dump-jira-exec.log
 
       - uses: nick-fields/assert-action@22dd2a66ef733fe92022d3704183ac007463eecb # v3.0.0
-        name: Then the Jira command to extract ticket details should have run smoothly
+        name: Then the Jira request to extract ticket details should have run smoothly
         with:
           expected: 0
           actual: ${{ steps.jira-content.outputs.status }}
@@ -241,19 +248,30 @@ jobs:
           actual: ${{ fromJSON(steps.jira-content.outputs.json_payload).fields.description }}
           comparison: exact
 
-      - name: Mark test ticket as resolved
-        run: jira resolve ${{ steps.test-data.outputs.issue }}
+      - name: Resolve and close the test ticket
+        if: always() && steps.test-data.outputs.issue != ''
         env:
           JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
           JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
           JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
-
-      - name: Mark test ticket as closed
-        run: jira close ${{ steps.test-data.outputs.issue }}
-        env:
-          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
-          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
-          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+          ISSUE_KEY: ${{ steps.test-data.outputs.issue }}
+        run: |
+          set +e
+          transition() {
+            tid="$(curl --silent --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+              --header 'Accept: application/json' \
+              "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions" \
+              | jq -r --arg n "$1" '.transitions[] | select(.name | ascii_downcase == ($n | ascii_downcase)) | .id' | head -n1)"
+            if [ -n "${tid}" ] && [ "${tid}" != "null" ]; then
+              curl --silent --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+                --header 'Content-Type: application/json' --request POST \
+                --data "{\"transition\":{\"id\":\"${tid}\"}}" \
+                "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions"
+            fi
+          }
+          for name in "Resolve Issue" "Resolve" "Done" "Close Issue" "Close"; do
+            transition "${name}"
+          done
 
   it-tests:
     name: "All IT Tests have to pass"

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -88,11 +88,12 @@ jobs:
           status=0
           if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
-          cp "$body" dump-jira-exec.log
+          jq . "$body" > dump-jira-exec.log 2>/dev/null || cp "$body" dump-jira-exec.log
           {
             echo 'json_payload<<EOF'
             cat dump-jira-exec.log
-            echo EOF
+            echo ""
+            echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: "Dump Jira issue payload"
@@ -225,11 +226,12 @@ jobs:
           status=0
           if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
-          cp "$body" dump-jira-exec.log
+          jq . "$body" > dump-jira-exec.log 2>/dev/null || cp "$body" dump-jira-exec.log
           {
             echo 'json_payload<<EOF'
             cat dump-jira-exec.log
-            echo EOF
+            echo ""
+            echo 'EOF'
           } >> "$GITHUB_OUTPUT"
       - name: "Dump Jira issue payload"
         run: cat dump-jira-exec.log

--- a/.github/workflows/it-test.yml
+++ b/.github/workflows/it-test.yml
@@ -40,6 +40,31 @@ jobs:
           actual: ${{ steps.test-data.outputs.issue }}
           comparison: startsWith
 
+      - name: Resolve and close the test ticket
+        if: always() && steps.test-data.outputs.issue != ''
+        env:
+          JIRA_BASE_URL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_url }}
+          JIRA_USER_EMAIL: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_user }}
+          JIRA_API_TOKEN: ${{ fromJSON(steps.vault-jira-sandbox-secrets.outputs.vault).jira_password }}
+          ISSUE_KEY: ${{ steps.test-data.outputs.issue }}
+        run: |
+          set +e
+          transition() {
+            tid="$(curl --silent --connect-timeout 30 --max-time 120 --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+              --header 'Accept: application/json' \
+              "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions" \
+              | jq -r --arg n "$1" '.transitions[] | select(.name | ascii_downcase == ($n | ascii_downcase)) | .id' | head -n1)"
+            if [ -n "${tid}" ] && [ "${tid}" != "null" ]; then
+              curl --silent --connect-timeout 30 --max-time 120 --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+                --header 'Content-Type: application/json' --request POST \
+                --data "{\"transition\":{\"id\":\"${tid}\"}}" \
+                "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions"
+            fi
+          }
+          for name in "Resolve Issue" "Resolve" "Done" "Close Issue" "Close"; do
+            transition "${name}"
+          done
+
   it-tests-check-all-inputs:
     name: "IT Test - given all inputs values are provided, they should be inserted correctly within the issue"
     runs-on: github-ubuntu-latest-s
@@ -81,12 +106,15 @@ jobs:
           set +e
           sleep 5 # Give some time to the Jira automation to transit issue Open -> Todo
           body="$(mktemp)"
-          code="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
+          code="$(curl --silent --show-error --connect-timeout 30 --max-time 120 \
+            --output "$body" --write-out '%{http_code}' \
             --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
             --header 'Accept: application/json' \
             "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}")"
+          curl_rc=$?
+          code="${code:-0}"
           status=0
-          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
+          if [ "$curl_rc" -ne 0 ] || [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
           jq . "$body" > dump-jira-exec.log 2>/dev/null || cp "$body" dump-jira-exec.log
           {
@@ -167,12 +195,12 @@ jobs:
           # Best-effort cleanup of the sandbox ticket (non-fatal): drive it to a terminal state
           # by name, regardless of the exact workflow transition ids.
           transition() {
-            tid="$(curl --silent --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            tid="$(curl --silent --connect-timeout 30 --max-time 120 --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
               --header 'Accept: application/json' \
               "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions" \
               | jq -r --arg n "$1" '.transitions[] | select(.name | ascii_downcase == ($n | ascii_downcase)) | .id' | head -n1)"
             if [ -n "${tid}" ] && [ "${tid}" != "null" ]; then
-              curl --silent --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+              curl --silent --connect-timeout 30 --max-time 120 --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
                 --header 'Content-Type: application/json' --request POST \
                 --data "{\"transition\":{\"id\":\"${tid}\"}}" \
                 "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions"
@@ -219,12 +247,15 @@ jobs:
           set +e
           sleep 5 # Give some time to the Jira automation to transit issue Open -> Todo
           body="$(mktemp)"
-          code="$(curl --silent --show-error --output "$body" --write-out '%{http_code}' \
+          code="$(curl --silent --show-error --connect-timeout 30 --max-time 120 \
+            --output "$body" --write-out '%{http_code}' \
             --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
             --header 'Accept: application/json' \
             "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}")"
+          curl_rc=$?
+          code="${code:-0}"
           status=0
-          if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
+          if [ "$curl_rc" -ne 0 ] || [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then status=1; fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
           jq . "$body" > dump-jira-exec.log 2>/dev/null || cp "$body" dump-jira-exec.log
           {
@@ -260,12 +291,12 @@ jobs:
         run: |
           set +e
           transition() {
-            tid="$(curl --silent --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            tid="$(curl --silent --connect-timeout 30 --max-time 120 --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
               --header 'Accept: application/json' \
               "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions" \
               | jq -r --arg n "$1" '.transitions[] | select(.name | ascii_downcase == ($n | ascii_downcase)) | .id' | head -n1)"
             if [ -n "${tid}" ] && [ "${tid}" != "null" ]; then
-              curl --silent --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+              curl --silent --connect-timeout 30 --max-time 120 --output /dev/null --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
                 --header 'Content-Type: application/json' --request POST \
                 --data "{\"transition\":{\"id\":\"${tid}\"}}" \
                 "${JIRA_BASE_URL%/}/rest/api/2/issue/${ISSUE_KEY}/transitions"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,25 @@
 Create Jira ticket
 
 > Note
-> This is a wrapper for GitHub action [atlassian/gajira-create](https://github.com/atlassian/gajira-create?tab=readme-ov-file)
-> with some extra features such as Markdown support for issue description.
+> This action creates the issue by calling the Jira Cloud REST API (v2) directly. It keeps
+> Markdown support for the issue description (converted to Jira wiki markup).
+>
+> It previously wrapped [atlassian/gajira-create](https://github.com/atlassian/gajira-create),
+> which was dropped because it is stuck on Node 16/20 and unmaintained (see BUILD-11506).
+
+## Authentication
+
+The action authenticates against Jira using **three environment variables** that you must set
+on the step (or job). They are the same variables the old `atlassian/gajira-login` consumed:
+
+| Env var | Description |
+|-----------------|-------------------------------------------------|
+| `JIRA_BASE_URL` | Base URL of the Jira instance (e.g. `https://xxx.atlassian.net`) |
+| `JIRA_USER_EMAIL` | Email of the Jira user / token owner |
+| `JIRA_API_TOKEN` | Jira API token (password) for that user |
+
+> Migration note: callers no longer run a separate `atlassian/gajira-login` step — instead pass
+> the three variables above as `env:` on the `gh-action_jira-create` step.
 
 ## Usage
 
@@ -16,7 +33,11 @@ Create Jira ticket
 
 ```yaml
 steps:
-  - uses: SonarSource/gh-action_jira-create@0.0.1 <--- replace with the last tag
+  - uses: SonarSource/gh-action_jira-create@0.0.1 # <--- replace with the last tag
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     with:
       project: <Jira project key>
       issuetype: <Task, ...>
@@ -28,7 +49,11 @@ steps:
 
 ```yaml
 steps:
-  - uses: SonarSource/gh-action_jira-create@0.0.1 <--- replace with the last tag
+  - uses: SonarSource/gh-action_jira-create@0.0.1 # <--- replace with the last tag
+    env:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
     with:
       project: <Jira project key>
       issuetype: <Task, ...>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Create Jira ticket
 > It previously wrapped [atlassian/gajira-create](https://github.com/atlassian/gajira-create),
 > which was dropped because it is stuck on Node 16/20 and unmaintained (see BUILD-11506).
 
+## Requirements
+
+The action runs a small Bash script, so the runner must have **`bash`**, **`curl`**, and **`jq`**
+available in `PATH` (GitHub-hosted Ubuntu runners include them by default).
+
 ## Authentication
 
 The action authenticates against Jira using **three environment variables** that you must set

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ runs:
       run: |
         set -euo pipefail
 
+        # This composite action shells out to curl and jq.
+        command -v jq >/dev/null 2>&1 || { echo "::error::jq is required but was not found in PATH"; exit 1; }
+        command -v curl >/dev/null 2>&1 || { echo "::error::curl is required but was not found in PATH"; exit 1; }
+
         # Credentials are read from the environment (same variable names the now-deprecated
         # atlassian/gajira-login consumed). Callers must export them before this action runs.
         : "${JIRA_BASE_URL:?Set JIRA_BASE_URL in the environment before calling gh-action_jira-create}"
@@ -50,6 +54,11 @@ runs:
         extra_fields="${ISSUE_FIELDS:-}"
         if [ -z "$extra_fields" ]; then
           extra_fields='{}'
+        fi
+        # Fail early with a clear message if `fields` is not a JSON object (avoids a cryptic jq error).
+        if ! printf '%s' "$extra_fields" | jq -e 'type == "object"' >/dev/null 2>&1; then
+          echo "::error::inputs.fields must be a valid JSON object, e.g. {\"priority\":{\"name\":\"Normal\"}}"
+          exit 1
         fi
 
         # Build the request body and merge any caller-provided extra fields.
@@ -67,11 +76,19 @@ runs:
               + $extra
           )}')"
 
+        # Pass credentials through a mode-600 curl config file rather than --user, so the API
+        # token is not exposed in the process arguments (visible via `ps`). Cleaned up on exit.
+        curl_cfg="$(mktemp)"
         response_body="$(mktemp)"
+        trap 'rm -f "$curl_cfg" "$response_body"' EXIT
+        chmod 600 "$curl_cfg"
+        printf 'user = "%s:%s"\n' "$JIRA_USER_EMAIL" "$JIRA_API_TOKEN" > "$curl_cfg"
+
         http_code="$(curl --silent --show-error \
+          --connect-timeout 30 --max-time 120 \
+          --config "$curl_cfg" \
           --output "$response_body" --write-out '%{http_code}' \
           --request POST \
-          --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
           --header 'Content-Type: application/json' \
           --data "$payload" \
           "${JIRA_BASE_URL%/}/rest/api/2/issue")"

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,61 @@ runs:
         mode: md2jira
     - name: Create Jira issue
       id: create
-      uses: atlassian/gajira-create@1ff0b6bd115a780592b47bfbb63fc4629132e6ec # v3
-      with:
-        project: ${{ inputs.project }}
-        issuetype: ${{ inputs.issuetype }}
-        summary: ${{ inputs.summary }}
-        description: ${{ steps.md2jira.outputs.output-text }}
-        fields: ${{ inputs.fields }}
+      shell: bash
+      env:
+        ISSUE_PROJECT: ${{ inputs.project }}
+        ISSUE_TYPE: ${{ inputs.issuetype }}
+        ISSUE_SUMMARY: ${{ inputs.summary }}
+        ISSUE_DESCRIPTION: ${{ steps.md2jira.outputs.output-text }}
+        ISSUE_FIELDS: ${{ inputs.fields }}
+      run: |
+        set -euo pipefail
+
+        # Credentials are read from the environment (same variable names the now-deprecated
+        # atlassian/gajira-login consumed). Callers must export them before this action runs.
+        : "${JIRA_BASE_URL:?Set JIRA_BASE_URL in the environment before calling gh-action_jira-create}"
+        : "${JIRA_USER_EMAIL:?Set JIRA_USER_EMAIL in the environment before calling gh-action_jira-create}"
+        : "${JIRA_API_TOKEN:?Set JIRA_API_TOKEN in the environment before calling gh-action_jira-create}"
+
+        extra_fields="${ISSUE_FIELDS:-}"
+        if [ -z "$extra_fields" ]; then
+          extra_fields='{}'
+        fi
+
+        # Build the request body and merge any caller-provided extra fields.
+        # REST API v2 is used on purpose: it accepts the Jira wiki-markup string produced by
+        # jira2md as the "description" (v3 would require Atlassian Document Format instead).
+        payload="$(jq -n \
+          --arg project "$ISSUE_PROJECT" \
+          --arg issuetype "$ISSUE_TYPE" \
+          --arg summary "$ISSUE_SUMMARY" \
+          --arg description "$ISSUE_DESCRIPTION" \
+          --argjson extra "$extra_fields" \
+          '{fields: (
+              {project: {key: $project}, issuetype: {name: $issuetype}, summary: $summary}
+              + (if $description == "" then {} else {description: $description} end)
+              + $extra
+          )}')"
+
+        response_body="$(mktemp)"
+        http_code="$(curl --silent --show-error \
+          --output "$response_body" --write-out '%{http_code}' \
+          --request POST \
+          --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+          --header 'Content-Type: application/json' \
+          --data "$payload" \
+          "${JIRA_BASE_URL%/}/rest/api/2/issue")"
+
+        if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+          echo "::error::Jira issue creation failed (HTTP ${http_code}): $(cat "$response_body")"
+          exit 1
+        fi
+
+        issue_key="$(jq -r '.key // empty' < "$response_body")"
+        if [ -z "$issue_key" ]; then
+          echo "::error::Jira response did not contain an issue key: $(cat "$response_body")"
+          exit 1
+        fi
+
+        echo "Created Jira issue: ${issue_key}"
+        echo "issue=${issue_key}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

`atlassian/gajira-create` (in `action.yml`) and `atlassian/gajira-cli` / `atlassian/gajira-login` (in `it-test.yml`) are **unmaintained and stuck on Node 16/20** (latest `v3.0.1`, Feb 2025). The Node 24 cascade ([BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781)) could not bump them ([#34](https://github.com/SonarSource/gh-action_jira-create/pull/34) left them behind). Tracked as [BUILD-11506](https://sonarsource.atlassian.net/browse/BUILD-11506).

**Decision (AC #1): option 2 — replace with direct Jira Cloud REST API calls** (curl). A community fork handling Jira credentials was rejected on supply-chain grounds; waiting (option 1) is a dead end since upstream is on Node 16.

## What changed

- **`action.yml`** — the create step now builds the request body with `jq` and POSTs to `\${JIRA_BASE_URL}/rest/api/2/issue` via `curl`, reading **`JIRA_BASE_URL` / `JIRA_USER_EMAIL` / `JIRA_API_TOKEN`** from the environment (the same variable names `gajira-login` consumed). The `jira2md` Markdown→wiki-markup step and all inputs/outputs (`project`, `issuetype`, `summary`, `description`, `fields` → `issue`) are unchanged.
  - **REST API v2 on purpose:** v2 accepts the wiki-markup string `description`; v3 would require Atlassian Document Format and break the contract.
- **`it-test.yml`** — removed `gajira-cli` + `gajira-login`; the creds are passed as `env:` on the action step, and the created issue is verified (and cleaned up) via `curl` REST. All existing assertions (`.fields.summary/description/status/priority/issuetype/project/reporter`) are preserved.
- **`README.md`** — documents the new `JIRA_*` env requirement and the migration away from `gajira-login`.

## ⚠️ Breaking change for consumers

Callers must now pass `JIRA_BASE_URL` / `JIRA_USER_EMAIL` / `JIRA_API_TOKEN` as `env:` on the step **instead of** running a separate `atlassian/gajira-login`. Affected consumers (follow-up PRs needed before they bump the tag):

- `SonarSource/port-actions` → `.github/workflows/create-jira-issue.yml`
- `SonarSource/sonar-enterprise` → `.github/workflows/community-build-release.yml`

## Acceptance criteria ([BUILD-11506](https://sonarsource.atlassian.net/browse/BUILD-11506))

- [x] Decision recorded (option 2 — direct REST)
- [x] `gh-action_jira-create` updated; `it-test.yml` rewritten to run end-to-end against Jira without gajira
- [ ] `it-test.yml` passes against the Jira sandbox (runs on this PR)

## Test plan

1. **CI on this PR:** `it-test.yml` creates real issues in the **Jira sandbox** (`operations/team/re/kv/data/jira-sandbox`) across 3 jobs — required-only, all-fields, and Markdown-conversion — and asserts the returned fields, then resolves/closes the test tickets. This is the end-to-end test.
2. **Manual check:** confirm the created sandbox issues have the expected summary/description/priority/type and that the run shows **no Node 20 deprecation warning**.
3. After merge + tag, land the consumer follow-ups (above), then bump their pin.

## Risk / rollback

`action.yml` logic is small and self-contained; the `issue` output contract is unchanged. Main risk is the consumer env migration (flagged above). Rollback = revert; but the old action is on Node 16 and will warn/fail under the enforced deprecation.

[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11506]: https://sonarsource.atlassian.net/browse/BUILD-11506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11506]: https://sonarsource.atlassian.net/browse/BUILD-11506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ